### PR TITLE
build: improve dagger module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           verb: call
           module: ci
-          args: run --src "."
+          args: validate

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .devbox
+.idea

--- a/ci/.gitattributes
+++ b/ci/.gitattributes
@@ -1,0 +1,2 @@
+/dagger.gen.go linguist-generated
+/querybuilder/** linguist-generated

--- a/ci/dagger.json
+++ b/ci/dagger.json
@@ -1,4 +1,5 @@
 {
   "name": "ci",
-  "sdk": "go"
+  "sdk": "go",
+  "root": ".."
 }

--- a/ci/main.go
+++ b/ci/main.go
@@ -1,31 +1,92 @@
 package main
 
-type CI struct{}
+import (
+	"path/filepath"
+	"runtime"
+)
 
-func (m *CI) devbox(src *Directory) *Container {
-	// TODO(kakkoyun): Use local container.
-	return dag.Container().
-		From("jetpackio/devbox-root-user:latest").
-		WithMountedDirectory("/code", src).
-		WithWorkdir("/code").
-		WithExec([]string{"devbox", "run", "--", "echo", "'Installed Packages.'"})
+func New() *CI {
+	return &CI{
+		Base: base().WithDirectory("/src", source()).WithWorkdir("/src"),
+	}
 }
 
-func (m *CI) build(src *Directory) *Container {
-	return m.devbox(src).
-		WithExec([]string{"devbox", "run", "build"})
+type CI struct {
+	// Base is the base container for the CI contains required dependencies, nix, devbox and the source code.
+	Base *Container
 }
 
-func (m *CI) generate(src *Directory) *Container {
-	return m.build(src).
-		WithExec([]string{"devbox", "run", "generate"})
-}
-
-func (m *CI) validate(src *Directory) *Container {
-	return m.generate(src).
+// Validate runs the build, format, and generate commands and checks if there are any changes in the source code except the out directory.
+func (m *CI) Validate() *Container {
+	return m.Base.
+		WithFocus().
+		WithExec([]string{"devbox", "run", "build", "format", "generate"}).
 		WithExec([]string{"git", "diff", "--exit-code", ":!out/"})
 }
 
-func (m *CI) Run(src *Directory) *Container {
-	return m.validate(src)
+// base returns a ubuntu container with nix and devbox installed.
+func base() *Container {
+	// base container
+
+	base := dag.Container().From("ubuntu:latest")
+
+	// install base dependencies
+
+	base = base.WithExec([]string{"apt-get", "update"})
+	base = base.WithExec([]string{"apt-get", "install", "-y", "curl", "git"})
+
+	// Mount the cache volume to the container
+
+	base = base.WithMountedCache("/nix", dag.CacheVolume("parca-dev-testdata-nix"))
+	base = base.WithMountedCache("/etc/nix", dag.CacheVolume("parca-dev-testdata-nix-etc"))
+
+	// install nix
+
+	base = base.WithExec([]string{"sh", "-c", "[ -f /etc/nix/group ] && cp /etc/nix/group /etc/group; exit 0"})
+	base = base.WithExec([]string{"sh", "-c", "[ -f /etc/nix/passwd ] && cp /etc/nix/passwd /etc/passwd; exit 0"})
+	base = base.WithExec([]string{"sh", "-c", "[ -f /etc/nix/shadow ] && cp /etc/nix/shadow /etc/shadow; exit 0"})
+	base = base.WithExec([]string{"sh", "-c", "[ ! -f /nix/receipt.json ] && curl --proto =https --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux --extra-conf \"sandbox = false\" --init none --no-confirm; exit 0"})
+	base = base.WithExec([]string{"cp", "/etc/group", "/etc/nix/group"})
+	base = base.WithExec([]string{"cp", "/etc/passwd", "/etc/nix/passwd"})
+	base = base.WithExec([]string{"cp", "/etc/shadow", "/etc/nix/shadow"})
+	base = base.WithExec([]string{"sed", "-i", "s/auto-allocate-uids = true/auto-allocate-uids = false/g", "/etc/nix/nix.conf"})
+	base = base.WithEnvVariable("PATH", "$PATH:/nix/var/nix/profiles/default/bin", ContainerWithEnvVariableOpts{Expand: true})
+
+	// install devbox
+
+	base = base.WithExec([]string{"adduser", "--disabled-password", "devbox"})
+	base = base.WithExec([]string{"addgroup", "devbox", "nixbld"})
+	base = base.WithEnvVariable("FORCE", "1")
+	base = base.WithExec([]string{"sh", "-c", "curl -fsSL https://get.jetpack.io/devbox | bash"})
+	base = base.WithExec([]string{"sh", "-c", `echo 'eval "$(devbox global shellenv --recompute)"' >> ~/.bashrc`})
+	base = base.WithExec([]string{"devbox", "version"})
+
+	return base
+}
+
+// root returns the root directory of the project as an absolute path.
+func root() string {
+	// get location of current file
+	_, current, _, _ := runtime.Caller(0)
+
+	return filepath.Join(filepath.Dir(current), "..")
+}
+
+// source returns a directory containing the source code of the project with the required files and directories.
+func source() *Directory {
+	return dag.Host().Directory(
+		root(),
+		HostDirectoryOpts{
+			Include: []string{
+				".git",
+				"jitdump/**",
+				"src/**",
+				"tables/**",
+				"vendored/**",
+				"devbox.*",
+				"go.*",
+				"build.go",
+			},
+		},
+	)
 }


### PR DESCRIPTION
Adds small improvements to `dagger` ci module

Commands:

- `dagger -m ci shell base` => opens a shell inside of the base container with nix, devbox and source code. 
- `dagger -m ci call validate` => runs `validate` target


Dagger version **v0.9.5** is used for this PR